### PR TITLE
Pin to v0.3 to fix build pipeline for now.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,4 +2,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3


### PR DESCRIPTION
Temporary fix for these issues by pinning ZMK build config workflow to v0.3.

https://github.com/petejohanson/blank-slate-zmk-config/issues/17
https://github.com/petejohanson/blank-slate-zmk-config/issues/16